### PR TITLE
Fix uninitialized printType warnings

### DIFF
--- a/include/Object.h
+++ b/include/Object.h
@@ -173,8 +173,9 @@ inline ValueType ArrayObject::arrayContentType() {
 }
 
 inline void ArrayObject::pushValue(Value value) {
-	assert(value.type == _arrayType);
-	_elements.push_back(value);
+        assert(value.type == _arrayType);
+        value.printType = value.type;
+        _elements.push_back(value);
 }
 
 inline Value ArrayObject::removeAt(uint32_t index) { // @suppress("unused function")

--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -75,11 +75,13 @@ void Frame::trocaLocalVariable(Value variableValue, uint32_t index) {
 		exit(1);
 	}
 
-	_localVariables[index] = variableValue;
+        variableValue.printType = variableValue.type;
+        _localVariables[index] = variableValue;
 }
 
 void Frame::empilharOperandStack(Value operand) {
-	_operandStack->push(operand);
+        operand.printType = operand.type;
+        _operandStack->push(operand);
 }
 
 Value Frame::desempilhaOperandStack() {

--- a/src/OperationsArithmetic.cpp
+++ b/src/OperationsArithmetic.cpp
@@ -190,6 +190,7 @@ void OperationsArithmetic::ladd() {
 
 	Value soma;
 	soma.type = ValueType::LONG;
+	soma.printType = ValueType::LONG;
 	soma.data.longValue = value_1.data.longValue + value_2.data.longValue;
 
 	topFrame->empilharOperandStack(soma);
@@ -206,6 +207,7 @@ void OperationsArithmetic::fadd() {
 
 	Value soma;
 	soma.type = ValueType::FLOAT;
+	soma.printType = ValueType::FLOAT;
 	soma.data.floatValue = value_1.data.floatValue + value_2.data.floatValue;
 
 	topFrame->empilharOperandStack(soma);
@@ -222,6 +224,7 @@ void OperationsArithmetic::dadd() {
 
 	Value soma;
 	soma.type = ValueType::DOUBLE;
+	soma.printType = ValueType::DOUBLE;
 	soma.data.doubleValue = value_1.data.doubleValue + value_2.data.doubleValue;
 
 	topFrame->empilharOperandStack(soma);
@@ -238,6 +241,7 @@ void OperationsArithmetic::isub() {
 
 	Value subtracao;
 	subtracao.type = ValueType::INT;
+	subtracao.printType = ValueType::INT;
 	subtracao.data.intValue = value_1.data.intValue - value_2.data.intValue;
 
 	topFrame->empilharOperandStack(subtracao);
@@ -254,6 +258,7 @@ void OperationsArithmetic::lsub() {
 
 	Value subtracao;
 	subtracao.type = ValueType::LONG;
+	subtracao.printType = ValueType::LONG;
 	subtracao.data.longValue = value_1.data.longValue - value_2.data.longValue;
 
 	topFrame->empilharOperandStack(subtracao);
@@ -270,6 +275,7 @@ void OperationsArithmetic::fsub() {
 
 	Value subtracao;
 	subtracao.type = ValueType::FLOAT;
+	subtracao.printType = ValueType::FLOAT;
 	subtracao.data.floatValue = value_1.data.floatValue - value_2.data.floatValue;
 
 	topFrame->empilharOperandStack(subtracao);
@@ -286,6 +292,7 @@ void OperationsArithmetic::dsub() {
 
 	Value subtracao;
 	subtracao.type = ValueType::DOUBLE;
+	subtracao.printType = ValueType::DOUBLE;
 	subtracao.data.doubleValue = value_1.data.doubleValue - value_2.data.doubleValue;
 
 	topFrame->empilharOperandStack(subtracao);
@@ -302,6 +309,7 @@ void OperationsArithmetic::imul() {
 
 	Value multiplicacao;
 	multiplicacao.type = ValueType::INT;
+	multiplicacao.printType = ValueType::INT;
 	multiplicacao.data.intValue = value_1.data.intValue * value_2.data.intValue;
 
 	topFrame->empilharOperandStack(multiplicacao);
@@ -318,6 +326,7 @@ void OperationsArithmetic::lmul() {
 
 	Value multiplicacao;
 	multiplicacao.type = ValueType::LONG;
+	multiplicacao.printType = ValueType::LONG;
 	multiplicacao.data.longValue = value_1.data.longValue * value_2.data.longValue;
 
 	topFrame->empilharOperandStack(multiplicacao);
@@ -334,6 +343,7 @@ void OperationsArithmetic::fmul() {
 
 	Value multiplicacao;
 	multiplicacao.type = ValueType::FLOAT;
+	multiplicacao.printType = ValueType::FLOAT;
 	multiplicacao.data.floatValue = value_1.data.floatValue * value_2.data.floatValue;
 
 	topFrame->empilharOperandStack(multiplicacao);
@@ -350,6 +360,7 @@ void OperationsArithmetic::dmul() {
 
 	Value multiplicacao;
 	multiplicacao.type = ValueType::DOUBLE;
+	multiplicacao.printType = ValueType::DOUBLE;
 	multiplicacao.data.doubleValue = value_1.data.doubleValue * value_2.data.doubleValue;
 
 	topFrame->empilharOperandStack(multiplicacao);
@@ -373,6 +384,7 @@ void OperationsArithmetic::idiv() {
 
 	Value divisao;
 	divisao.type = ValueType::INT;
+	divisao.printType = ValueType::INT;
 	divisao.data.intValue = value_1.data.intValue / value_2.data.intValue;
 
 	topFrame->empilharOperandStack(divisao);
@@ -394,6 +406,7 @@ void OperationsArithmetic::ldiv() {
 
 	Value divisao;
 	divisao.type = ValueType::LONG;
+	divisao.printType = ValueType::LONG;
 	divisao.data.longValue = value_1.data.longValue / value_2.data.longValue;
 
 	topFrame->empilharOperandStack(divisao);
@@ -410,6 +423,7 @@ void OperationsArithmetic::fdiv() {
 
 	Value divisao;
 	divisao.type = ValueType::FLOAT;
+	divisao.printType = ValueType::FLOAT;
 	divisao.data.floatValue = value_1.data.floatValue / value_2.data.floatValue;
 
 	topFrame->empilharOperandStack(divisao);
@@ -426,6 +440,7 @@ void OperationsArithmetic::ddiv() {
 
 	Value divisao;
 	divisao.type = ValueType::DOUBLE;
+	divisao.printType = ValueType::DOUBLE;
 	divisao.data.doubleValue = value_1.data.doubleValue / value_2.data.doubleValue;
 
 	topFrame->empilharOperandStack(divisao);
@@ -449,6 +464,7 @@ void OperationsArithmetic::irem() {
 
 	Value resto;
 	resto.type = ValueType::INT;
+	resto.printType = ValueType::INT;
 	resto.data.intValue = value_1.data.intValue % value_2.data.intValue;
 
 	topFrame->empilharOperandStack(resto);
@@ -470,6 +486,7 @@ void OperationsArithmetic::lrem() {
 
 	Value resto;
 	resto.type = ValueType::LONG;
+	resto.printType = ValueType::LONG;
 	resto.data.longValue = value_1.data.longValue % value_2.data.longValue;
 
 	topFrame->empilharOperandStack(resto);
@@ -486,6 +503,7 @@ void OperationsArithmetic::frem() {
 
 	Value resto;
 	resto.type = ValueType::FLOAT;
+	resto.printType = ValueType::FLOAT;
 	resto.data.floatValue = fmod(value_1.data.floatValue, value_2.data.floatValue);
 
 	topFrame->empilharOperandStack(resto);
@@ -502,6 +520,7 @@ void OperationsArithmetic::drem() {
 
 	Value resto;
 	resto.type = ValueType::DOUBLE;
+	resto.printType = ValueType::DOUBLE;
 	resto.data.doubleValue = fmod(value_1.data.doubleValue, value_2.data.doubleValue);
 
 	topFrame->empilharOperandStack(resto);
@@ -519,6 +538,7 @@ void OperationsArithmetic::ineg() {
 
 	Value negacao;
 	negacao.type = ValueType::INT;
+	negacao.printType = ValueType::INT;
 	negacao.data.intValue = -value.data.intValue;
 
 	topFrame->empilharOperandStack(negacao);
@@ -534,6 +554,7 @@ void OperationsArithmetic::lneg() {
 
 	Value negacao;
 	negacao.type = ValueType::LONG;
+	negacao.printType = ValueType::LONG;
 	negacao.data.longValue = -value.data.longValue;
 
 	topFrame->empilharOperandStack(negacao);
@@ -549,6 +570,7 @@ void OperationsArithmetic::fneg() {
 
 	Value negacao;
 	negacao.type = ValueType::FLOAT;
+	negacao.printType = ValueType::FLOAT;
 	negacao.data.floatValue = -value.data.floatValue;
 
 	topFrame->empilharOperandStack(negacao);
@@ -564,6 +586,7 @@ void OperationsArithmetic::dneg() {
 
 	Value negacao;
 	negacao.type = ValueType::DOUBLE;
+	negacao.printType = ValueType::DOUBLE;
 	negacao.data.doubleValue = -value.data.doubleValue;
 
 	topFrame->empilharOperandStack(negacao);
@@ -582,6 +605,7 @@ void OperationsArithmetic::ishl() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = value_1.data.intValue << (value_2.data.intValue & 0x1f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -598,6 +622,7 @@ void OperationsArithmetic::lshl() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = value_1.data.longValue << (value_2.data.intValue & 0x3f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -614,6 +639,7 @@ void OperationsArithmetic::ishr() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = value_1.data.intValue >> (value_2.data.intValue & 0x1f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -630,6 +656,7 @@ void OperationsArithmetic::lshr() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = value_1.data.longValue >> (value_2.data.intValue & 0x3f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -646,6 +673,7 @@ void OperationsArithmetic::iushr() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = (uint32_t)value_1.data.intValue >> (value_2.data.intValue & 0x1f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -662,6 +690,7 @@ void OperationsArithmetic::lushr() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = (uint64_t)value_1.data.longValue >> (value_2.data.intValue & 0x3f);
 
 	topFrame->empilharOperandStack(resultado);
@@ -680,6 +709,7 @@ void OperationsArithmetic::iand() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = value_1.data.intValue & value_2.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -696,6 +726,7 @@ void OperationsArithmetic::land() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = value_1.data.longValue & value_2.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -712,6 +743,7 @@ void OperationsArithmetic::ior() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = value_1.data.intValue | value_2.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -728,6 +760,7 @@ void OperationsArithmetic::lor() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = value_1.data.longValue | value_2.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -744,6 +777,7 @@ void OperationsArithmetic::ixor() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = value_1.data.intValue ^ value_2.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -760,6 +794,7 @@ void OperationsArithmetic::lxor() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = value_1.data.longValue ^ value_2.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -802,6 +837,7 @@ void OperationsArithmetic::i2l() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = (int64_t)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -817,6 +853,7 @@ void OperationsArithmetic::i2f() {
 
 	Value resultado;
 	resultado.type = ValueType::FLOAT;
+	resultado.printType = ValueType::FLOAT;
 	resultado.data.floatValue = (float)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -832,6 +869,7 @@ void OperationsArithmetic::i2d() {
 
 	Value resultado;
 	resultado.type = ValueType::DOUBLE;
+	resultado.printType = ValueType::DOUBLE;
 	resultado.data.doubleValue = (double)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -847,6 +885,7 @@ void OperationsArithmetic::l2i() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = (int32_t)value.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -862,6 +901,7 @@ void OperationsArithmetic::l2f() {
 
 	Value resultado;
 	resultado.type = ValueType::FLOAT;
+	resultado.printType = ValueType::FLOAT;
 	resultado.data.floatValue = (float)value.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -877,6 +917,7 @@ void OperationsArithmetic::l2d() {
 
 	Value resultado;
 	resultado.type = ValueType::DOUBLE;
+	resultado.printType = ValueType::DOUBLE;
 	resultado.data.doubleValue = (double)value.data.longValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -892,6 +933,7 @@ void OperationsArithmetic::f2i() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = (int32_t)value.data.floatValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -907,6 +949,7 @@ void OperationsArithmetic::f2l() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = (int64_t)value.data.floatValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -922,6 +965,7 @@ void OperationsArithmetic::f2d() {
 
 	Value resultado;
 	resultado.type = ValueType::DOUBLE;
+	resultado.printType = ValueType::DOUBLE;
 	resultado.data.doubleValue = (double)value.data.floatValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -937,6 +981,7 @@ void OperationsArithmetic::d2i() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 	resultado.data.intValue = (int32_t)value.data.doubleValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -952,6 +997,7 @@ void OperationsArithmetic::d2l() {
 
 	Value resultado;
 	resultado.type = ValueType::LONG;
+	resultado.printType = ValueType::LONG;
 	resultado.data.longValue = (int64_t)value.data.doubleValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -967,6 +1013,7 @@ void OperationsArithmetic::d2f() {
 
 	Value resultado;
 	resultado.type = ValueType::FLOAT;
+	resultado.printType = ValueType::FLOAT;
 	resultado.data.floatValue = (float)value.data.doubleValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -982,6 +1029,7 @@ void OperationsArithmetic::i2b() {
 
 	Value resultado;
 	resultado.type = ValueType::BYTE;
+	resultado.printType = ValueType::BYTE;
 	resultado.data.byteValue = (int8_t)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -997,6 +1045,7 @@ void OperationsArithmetic::i2c() {
 
 	Value resultado;
 	resultado.type = ValueType::CHAR;
+	resultado.printType = ValueType::CHAR;
 	resultado.data.charValue = (uint8_t)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -1012,6 +1061,7 @@ void OperationsArithmetic::i2s() {
 
 	Value resultado;
 	resultado.type = ValueType::SHORT;
+	resultado.printType = ValueType::SHORT;
 	resultado.data.shortValue = (int16_t)value.data.intValue;
 
 	topFrame->empilharOperandStack(resultado);
@@ -1030,6 +1080,7 @@ void OperationsArithmetic::lcmp() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 
 	if (value_1.data.longValue > value_2.data.longValue) {
 		resultado.data.intValue = 1;
@@ -1053,6 +1104,7 @@ void OperationsArithmetic::fcmpl() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 
 	if (isnan(value_1.data.floatValue) || isnan(value_2.data.floatValue)) {
 		resultado.data.intValue = -1;
@@ -1078,6 +1130,7 @@ void OperationsArithmetic::fcmpg() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 
 	if (isnan(value_1.data.floatValue) || isnan(value_2.data.floatValue)) {
 		resultado.data.intValue = 1;
@@ -1103,6 +1156,7 @@ void OperationsArithmetic::dcmpl() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 
 	if (isnan(value_1.data.doubleValue) || isnan(value_2.data.doubleValue)) {
 		resultado.data.intValue = -1;
@@ -1128,6 +1182,7 @@ void OperationsArithmetic::dcmpg() {
 
 	Value resultado;
 	resultado.type = ValueType::INT;
+	resultado.printType = ValueType::INT;
 
 	if (isnan(value_1.data.doubleValue) || isnan(value_2.data.doubleValue)) {
 		resultado.data.intValue = 1;

--- a/src/OperationsConstants.cpp
+++ b/src/OperationsConstants.cpp
@@ -13,6 +13,7 @@ void OperationsConstants::aconst_null() {
 
 	Value value;
 	value.type = ValueType::REFERENCE;
+	value.printType = ValueType::REFERENCE;
 	value.data.object = NULL;
 
 	topFrame->empilharOperandStack(value);
@@ -27,6 +28,7 @@ void OperationsConstants::iconst_m1() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = -1;
 
 	topFrame->empilharOperandStack(value);
@@ -41,6 +43,7 @@ void OperationsConstants::iconst_0() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 0;
 
 	topFrame->empilharOperandStack(value);
@@ -55,6 +58,7 @@ void OperationsConstants::iconst_1() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 1;
 
 	topFrame->empilharOperandStack(value);
@@ -69,6 +73,7 @@ void OperationsConstants::iconst_2() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 2;
 
 	topFrame->empilharOperandStack(value);
@@ -83,6 +88,7 @@ void OperationsConstants::iconst_3() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 3;
 
 	topFrame->empilharOperandStack(value);
@@ -97,6 +103,7 @@ void OperationsConstants::iconst_4() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 4;
 
 	topFrame->empilharOperandStack(value);
@@ -111,6 +118,7 @@ void OperationsConstants::iconst_5() {
 	Value value;
 	value.printType = ValueType::INT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = 5;
 
 	topFrame->empilharOperandStack(value);
@@ -125,6 +133,7 @@ void OperationsConstants::lconst_0() {
 	Value value;
 	value.printType = ValueType::LONG;
 	value.type = ValueType::LONG;
+	value.printType = ValueType::LONG;
 	value.data.longValue = 0;
 
 	topFrame->empilharOperandStack(value);
@@ -139,6 +148,7 @@ void OperationsConstants::lconst_1() {
 	Value value;
 	value.printType = ValueType::LONG;
 	value.type = ValueType::LONG;
+	value.printType = ValueType::LONG;
 	value.data.longValue = 1;
 
 	topFrame->empilharOperandStack(value);
@@ -152,6 +162,7 @@ void OperationsConstants::fconst_0() {
 
 	Value value;
 	value.type = ValueType::FLOAT;
+	value.printType = ValueType::FLOAT;
 	value.data.floatValue = 0.0f;
 
 	topFrame->empilharOperandStack(value);
@@ -165,6 +176,7 @@ void OperationsConstants::fconst_1() {
 
 	Value value;
 	value.type = ValueType::FLOAT;
+	value.printType = ValueType::FLOAT;
 	value.data.floatValue = 1.0f;
 
 	topFrame->empilharOperandStack(value);
@@ -178,6 +190,7 @@ void OperationsConstants::fconst_2() {
 
 	Value value;
 	value.type = ValueType::FLOAT;
+	value.printType = ValueType::FLOAT;
 	value.data.floatValue = 2.0f;
 
 	topFrame->empilharOperandStack(value);
@@ -191,6 +204,7 @@ void OperationsConstants::dconst_0() {
 
 	Value value;
 	value.type = ValueType::DOUBLE;
+	value.printType = ValueType::DOUBLE;
 	value.data.doubleValue = 0.0;
 
 	topFrame->empilharOperandStack(value);
@@ -204,6 +218,7 @@ void OperationsConstants::dconst_1() {
 
 	Value value;
 	value.type = ValueType::DOUBLE;
+	value.printType = ValueType::DOUBLE;
 	value.data.doubleValue = 1.0;
 
 	topFrame->empilharOperandStack(value);
@@ -221,6 +236,7 @@ void OperationsConstants::bipush() {
 	Value value;
 	value.printType = ValueType::BYTE;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = (int32_t) (int8_t) byte; // convertendo para inteiro e estendendo o sinal
 
 	topFrame->empilharOperandStack(value);
@@ -240,6 +256,7 @@ void OperationsConstants::sipush() {
 	Value value;
 	value.printType = ValueType::SHORT;
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 	value.data.intValue = (int32_t) (int16_t) shortValue; // convertendo para inteiro e estendendo o sinal
 
 	topFrame->empilharOperandStack(value);
@@ -272,10 +289,12 @@ void OperationsConstants::ldc() {
 		utf8String[i] = '\0';
 
 		value.type = ValueType::REFERENCE;
+		value.printType = ValueType::REFERENCE;
 		value.data.object = new StringObject(utf8String);
 	} else if (entry.tag == CONSTANT_Integer) {
 		value.printType = ValueType::INT;
 		value.type = ValueType::INT;
+		value.printType = ValueType::INT;
 		value.data.intValue = (int32_t) entry.info.integer_info.bytes;
 	} else if (entry.tag == CONSTANT_Float) {
 		u4 floatBytes = entry.info.float_info.bytes;
@@ -285,6 +304,7 @@ void OperationsConstants::ldc() {
 
 		float number = s * m * pow(2, e - 150);
 		value.type = ValueType::FLOAT;
+		value.printType = ValueType::FLOAT;
 		value.data.floatValue = number;
 	} else {
 		cerr << "ldc tentando acessar um elemento da CP invalido: " << entry.tag << endl;
@@ -322,10 +342,12 @@ void OperationsConstants::ldc_w() {
 		utf8String[i] = '\0';
 
 		value.type = ValueType::REFERENCE;
+		value.printType = ValueType::REFERENCE;
 		value.data.object = new StringObject(utf8String);
 	} else if (entry.tag == CONSTANT_Integer) {
 		value.printType = ValueType::INT;
 		value.type = ValueType::INT;
+		value.printType = ValueType::INT;
 		value.data.intValue = entry.info.integer_info.bytes;
 	} else if (entry.tag == CONSTANT_Float) {
 		u4 floatBytes = entry.info.float_info.bytes;
@@ -335,6 +357,7 @@ void OperationsConstants::ldc_w() {
 
 		float number = s * m * pow(2, e - 150);
 		value.type = ValueType::FLOAT;
+		value.printType = ValueType::FLOAT;
 		value.data.floatValue = number;
 	} else {
 		cerr << "ldc_w tentando acessar um elemento da CP invalido: " << entry.tag << endl;
@@ -365,10 +388,12 @@ void OperationsConstants::ldc2_w() {
 
 		int64_t longNumber = ((int64_t) highBytes << 32) + lowBytes;
 		value.type = ValueType::LONG;
+		value.printType = ValueType::LONG;
 		value.data.longValue = longNumber;
 
 		Value padding;
 		padding.type = ValueType::PADDING;
+		padding.printType = ValueType::PADDING;
 
 		topFrame->empilharOperandStack(padding);
 	} else if (entry.tag == CONSTANT_Double) {
@@ -383,10 +408,12 @@ void OperationsConstants::ldc2_w() {
 
 		double doubleNumber = s * m * pow(2, e - 1075);
 		value.type = ValueType::DOUBLE;
+		value.printType = ValueType::DOUBLE;
 		value.data.doubleValue = doubleNumber;
 
 		Value padding;
 		padding.type = ValueType::PADDING;
+		padding.printType = ValueType::PADDING;
 
 		topFrame->empilharOperandStack(padding);
 	} else {

--- a/src/OperationsControl.cpp
+++ b/src/OperationsControl.cpp
@@ -307,6 +307,7 @@ void OperationsControl::jsr() {
 
 	Value returnAddr;
 	returnAddr.type = ValueType::RETURN_ADDR;
+	returnAddr.printType = ValueType::RETURN_ADDR;
 	returnAddr.data.returnAddress = topFrame->pc + 3;
 	topFrame->empilharOperandStack(returnAddr);
 
@@ -460,6 +461,7 @@ void OperationsControl::lreturn() {
 	Frame *newTopFrame = stackFrame.getTopFrame();
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 	newTopFrame->empilharOperandStack(padding);
 	newTopFrame->empilharOperandStack(returnValue);
 }
@@ -491,6 +493,7 @@ void OperationsControl::dreturn() {
 
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 	newTopFrame->empilharOperandStack(padding);
 	newTopFrame->empilharOperandStack(returnValue);
 }
@@ -580,6 +583,7 @@ void OperationsControl::jsr_w() {
 
 	Value returnAddr;
 	returnAddr.type = ValueType::RETURN_ADDR;
+	returnAddr.printType = ValueType::RETURN_ADDR;
 	returnAddr.data.returnAddress = topFrame->pc + 5;
 	topFrame->empilharOperandStack(returnAddr);
 

--- a/src/OperationsLoadStore.cpp
+++ b/src/OperationsLoadStore.cpp
@@ -59,6 +59,7 @@ void OperationsLoadStore::lload() {
 
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 
 	topFrame->empilharOperandStack(padding);
 	topFrame->empilharOperandStack(value);
@@ -113,6 +114,7 @@ void OperationsLoadStore::dload() {
 
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 
 	topFrame->empilharOperandStack(padding);
 	topFrame->empilharOperandStack(value);
@@ -464,6 +466,7 @@ void OperationsLoadStore::laload() {
 
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 
 	topFrame->empilharOperandStack(padding);
 	topFrame->empilharOperandStack(array->getValue(index.data.intValue));
@@ -520,6 +523,7 @@ void OperationsLoadStore::daload() {
 
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 
 	topFrame->empilharOperandStack(padding);
 	topFrame->empilharOperandStack(array->getValue(index.data.intValue));
@@ -585,6 +589,7 @@ void OperationsLoadStore::baload() {
 		value.printType = ValueType::BYTE;
 	}
 	value.type = ValueType::INT;
+	value.printType = ValueType::INT;
 
 	topFrame->empilharOperandStack(value);
 	topFrame->pc += 1;
@@ -616,6 +621,7 @@ void OperationsLoadStore::caload() {
 	charValue.data.intValue = (uint32_t) charValue.data.charValue;
 	charValue.printType = ValueType::CHAR;
 	charValue.type = ValueType::INT;
+	charValue.printType = ValueType::INT;
 
 	topFrame->empilharOperandStack(charValue);
 	topFrame->pc += 1;
@@ -647,6 +653,7 @@ void OperationsLoadStore::saload() {
 	shortValue.data.intValue = (int32_t) shortValue.data.shortValue;
 	shortValue.printType = ValueType::SHORT;
 	shortValue.type = ValueType::INT;
+	shortValue.printType = ValueType::INT;
 
 	topFrame->empilharOperandStack(shortValue);
 	topFrame->pc += 1;
@@ -705,6 +712,7 @@ void OperationsLoadStore::lstore() {
 	topFrame->trocaLocalVariable(value, index);
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 	topFrame->trocaLocalVariable(padding, index + 1);
 }
 
@@ -759,6 +767,7 @@ void OperationsLoadStore::dstore() {
 	topFrame->trocaLocalVariable(value, index);
 	Value padding;
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 	topFrame->trocaLocalVariable(padding, index + 1);
 }
 
@@ -1265,6 +1274,7 @@ void OperationsLoadStore::castore() {
 	value.data.charValue = (uint8_t) value.data.intValue;
 	value.printType = ValueType::CHAR;
 	value.type = ValueType::CHAR;
+	value.printType = ValueType::CHAR;
 	array->changeValueAt(index.data.intValue, value);
 
 	topFrame->pc += 1;
@@ -1297,6 +1307,7 @@ void OperationsLoadStore::sastore() {
 	value.data.shortValue = (int16_t) value.data.intValue;
 	value.printType = ValueType::SHORT;
 	value.type = ValueType::SHORT;
+	value.printType = ValueType::SHORT;
 	array->changeValueAt(index.data.intValue, value);
 
 	topFrame->pc += 1;

--- a/src/OperationsObject.cpp
+++ b/src/OperationsObject.cpp
@@ -100,6 +100,7 @@ void OperationsObject::getstatic() {
 	if (staticValue.type == ValueType::DOUBLE || staticValue.type == ValueType::LONG) {
 		Value paddingValue;
 		paddingValue.type = ValueType::PADDING;
+		paddingValue.printType = ValueType::PADDING;
 		topFrame->empilharOperandStack(paddingValue);
 	}
 
@@ -249,6 +250,7 @@ void OperationsObject::getfield() {
 	if (fieldValue.type == ValueType::DOUBLE || fieldValue.type == ValueType::LONG) {
 		Value paddingValue;
 		paddingValue.type = ValueType::PADDING;
+		paddingValue.printType = ValueType::PADDING;
 		topFrame->empilharOperandStack(paddingValue);
 	}
 
@@ -423,6 +425,7 @@ void OperationsObject::invokevirtual() {
 			Value result;
 			result.printType = ValueType::INT;
 			result.type = ValueType::INT;
+			result.printType = ValueType::INT;
 			if (str1->getString() == str2->getString()) {
 				result.data.intValue = 1;
 			} else {
@@ -439,6 +442,7 @@ void OperationsObject::invokevirtual() {
 			Value result;
 			result.printType = ValueType::INT;
 			result.type = ValueType::INT;
+			result.printType = ValueType::INT;
 			result.data.intValue = (str->getString()).size();
 			topFrame->empilharOperandStack(result);
 		} else {
@@ -814,6 +818,7 @@ void OperationsObject::func_new() {
 	Value objectref;
 	objectref.data.object = object;
 	objectref.type = ValueType::REFERENCE;
+	objectref.printType = ValueType::REFERENCE;
 	topFrame->empilharOperandStack(objectref);
 
 	topFrame->pc += 3;
@@ -838,6 +843,7 @@ void OperationsObject::newarray() {
 	Value padding;
 	UNUSED(padding);
 	padding.type = ValueType::PADDING;
+	padding.printType = ValueType::PADDING;
 
 	const u1 *code = topFrame->getCode(topFrame->pc);
 	switch (code[1]) { // argumento representa tipo do array
@@ -914,6 +920,7 @@ void OperationsObject::newarray() {
 
 	Value arrayref; // Referencia pro array na pilha de operandos
 	arrayref.type = ValueType::REFERENCE;
+	arrayref.printType = ValueType::REFERENCE;
 	arrayref.data.object = array;
 
 	topFrame->empilharOperandStack(arrayref);
@@ -956,11 +963,13 @@ void OperationsObject::anewarray() {
 	// criando objeto da classe instanciada
 	Value objectref;
 	objectref.type = ValueType::REFERENCE;
+	objectref.printType = ValueType::REFERENCE;
 	objectref.data.object = new ArrayObject(ValueType::REFERENCE);
 
 	// populando array com NULL
 	Value nullValue;
 	nullValue.type = ValueType::REFERENCE;
+	nullValue.printType = ValueType::REFERENCE;
 	nullValue.data.object = NULL;
 	for (int i = 0; i < count.data.intValue; i++) {
 		static_cast<ArrayObject *>(objectref.data.object)->pushValue(nullValue);
@@ -984,6 +993,7 @@ void OperationsObject::arraylength() {
 
 	Value length;
 	length.type = ValueType::INT;
+	length.printType = ValueType::INT;
 	length.data.intValue = static_cast<ArrayObject *>(arrayref.data.object)->getSize();
 
 	topFrame->empilharOperandStack(length);
@@ -1017,6 +1027,7 @@ void OperationsObject::checkcast() {
 
 	Value resultValue;
 	resultValue.type = ValueType::INT;
+	resultValue.printType = ValueType::INT;
 
 	if (objectrefValue.data.object == NULL) {
 		cerr << "ClassCastException" << endl;
@@ -1083,6 +1094,7 @@ void OperationsObject::instanceof() {
 
 	Value resultValue;
 	resultValue.type = ValueType::INT;
+	resultValue.printType = ValueType::INT;
 
 	if (objectrefValue.data.object == NULL) {
 		resultValue.data.intValue = 0;
@@ -1248,6 +1260,7 @@ void OperationsObject::multianewarray() {
 				// For deeper nesting, create null references
 				Value nullValue;
 				nullValue.type = ValueType::REFERENCE;
+				nullValue.printType = ValueType::REFERENCE;
 				nullValue.data.object = NULL;
 				for (int j = 0; j < subCurrCount; j++) {
 					subArray->pushValue(nullValue);
@@ -1256,6 +1269,7 @@ void OperationsObject::multianewarray() {
 			
 			Value subArrayValue;
 			subArrayValue.type = ValueType::REFERENCE;
+			subArrayValue.printType = ValueType::REFERENCE;
 			subArrayValue.data.object = subArray;
 			array->pushValue(subArrayValue);
 		}
@@ -1263,6 +1277,7 @@ void OperationsObject::multianewarray() {
 
 	Value arrayValue;
 	arrayValue.type = ValueType::REFERENCE;
+	arrayValue.printType = ValueType::REFERENCE;
 	arrayValue.data.object = array;
 
 	topFrame->empilharOperandStack(arrayValue);


### PR DESCRIPTION
## Summary
- initialize `printType` when pushing values to the operand stack, storing locals, or adding to arrays
- automatically set `printType` for values created in operations

## Testing
- `make -j$(nproc)`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68770d326a1883239121b8451178d007